### PR TITLE
Add CMake requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the monorepo using [nx](https://nx.dev) that contains the source for the
 
 ## Getting started with development
 
-In the project root run `yarn install`, this will install all the required dependencies across all the projects. You will need `cocoapods`, a valid JDK installation, and Gradle 7 installed on your Mac. `nx` as a global dependency is optional.
+In the project root run `yarn install`, this will install all the required dependencies across all the projects. You will need `cocoapods`, a valid JDK installation, CMake 3.10.2 (Android only, available through Android Studio), and Gradle 7 installed on your Mac. `nx` as a global dependency is optional.
 
 #### To run the iOS apps in development
 


### PR DESCRIPTION
Adds reference to needing CMake 3.10.2 installed in order to build
the Android versions of the apps.