### PR TITLE
Add ability to scroll with carousel

### DIFF
--- a/apps/box/src/components/Cards/CardCarousel.tsx
+++ b/apps/box/src/components/Cards/CardCarousel.tsx
@@ -32,6 +32,9 @@ export const CardCarousel = ({
         loop={false}
         width={(WINDOW_WIDTH - CARD_SPACING) * SCALE}
         height={height}
+        panGestureHandlerProps={{
+          activeOffsetX: [-10, 10],
+        }}
         style={{
           width: WINDOW_WIDTH,
         }}


### PR DESCRIPTION
Previously when a card carousel was within a list, scrolling the list was not working due to carousel component consuming the gestures. This adds additional props to allow scrolling if the offset thresholds aren't surpassed.