### PR TITLE
Update FxTag default props

### DIFF
--- a/libs/component-library/src/lib/tag/tag.tsx
+++ b/libs/component-library/src/lib/tag/tag.tsx
@@ -26,6 +26,7 @@ const FxTag = (props: FxTagProps) => {
       height={26}
       justifyContent="center"
       paddingHorizontal="8"
+      alignSelf="flex-start"
       {...rest}
     >
       <FxText color="content1" variant="bodyXXSRegular">


### PR DESCRIPTION
Updates FxTag to alignSelf as flex-start to prevent tag from stretching
larger than intended.