### PR TITLE
Task/radio buttons comp lib

### DIFF
--- a/libs/component-library/src/index.ts
+++ b/libs/component-library/src/index.ts
@@ -11,6 +11,7 @@ export { FxCard, FxCardProps } from './lib/card/card';
 export { FxSwitch } from './lib/switch/switch';
 export * from './lib/icons/icons';
 export { FxError } from './lib/error/error';
+export { FxRadioButton } from './lib/radio-button';
 export { FxFoldableContent } from './lib/foldable-content/foldableContent';
 export { FxHorizontalRule } from './lib/horizontal-rule/horizontalRule';
 export { FxLineChart } from './lib/line-chart/lineChart';

--- a/libs/component-library/src/lib/pressable-opacity/pressableOpacity.tsx
+++ b/libs/component-library/src/lib/pressable-opacity/pressableOpacity.tsx
@@ -5,7 +5,7 @@ import { FxTheme } from '../theme/theme';
 
 const PressableBox = createBox<FxTheme, PressableProps>(Pressable);
 
-type FxPressableOpacityProps = React.ComponentProps<typeof PressableBox>;
+export type FxPressableOpacityProps = React.ComponentProps<typeof PressableBox>;
 
 export const FxPressableOpacity = ({
   style,

--- a/libs/component-library/src/lib/radio-button/RadioButton.tsx
+++ b/libs/component-library/src/lib/radio-button/RadioButton.tsx
@@ -65,7 +65,7 @@ const BORDER_WIDTH_CHECKED = 6;
  * ```js
  * import * as React from 'react';
  * import { View } from 'react-native';
- * import { RadioButton } from 'react-native-paper';
+ * import { RadioButton } from '@functionland/component-library';
  *
  * const MyComponent = () => {
  *   const [checked, setChecked] = React.useState('first');

--- a/libs/component-library/src/lib/radio-button/RadioButton.tsx
+++ b/libs/component-library/src/lib/radio-button/RadioButton.tsx
@@ -1,0 +1,228 @@
+import { createBox, useTheme } from '@shopify/restyle';
+import * as React from 'react';
+import {
+  Animated,
+  View,
+  StyleSheet,
+  TouchableOpacity,
+  TouchableOpacityProps,
+} from 'react-native';
+import { FxTheme } from '../theme/theme';
+
+import type { $RemoveChildren } from './../types';
+
+import { useRadioButtonContext } from './RadioButtonGroup';
+import { handlePress, isChecked } from './utils';
+
+const TouchableBox = createBox<FxTheme, TouchableOpacityProps>(
+  TouchableOpacity
+);
+
+type Props = $RemoveChildren<typeof TouchableBox> & {
+  /**
+   * Value of the radio button
+   */
+  value: string;
+  /**
+   * Status of radio button.
+   */
+  status?: 'checked' | 'unchecked';
+  /**
+   * Whether radio is disabled.
+   */
+  disabled?: boolean;
+  /**
+   * Function to execute on press.
+   */
+  onPress?: () => void;
+  /**
+   * Custom color for radio.
+   */
+  checkedColor?: string;
+  /**
+   * Custom color for unchecked radio.
+   */
+  uncheckedColor?: string;
+  /**
+   * Custom color for radio.
+   */
+  checkedDisabledColor?: string;
+  /**
+   * Custom color for unchecked disabled radio.
+   */
+  uncheckedDisabledColor?: string;
+  /**
+   * Custom color for unchecked disabled radio.
+   */
+  uncheckedDisabledBackgroundColor?: string;
+};
+
+const BORDER_WIDTH = 1;
+const BORDER_WIDTH_CHECKED = 6;
+
+/**
+ * ## Usage
+ * ```js
+ * import * as React from 'react';
+ * import { View } from 'react-native';
+ * import { RadioButton } from 'react-native-paper';
+ *
+ * const MyComponent = () => {
+ *   const [checked, setChecked] = React.useState('first');
+ *
+ *   return (
+ *     <View>
+ *       <RadioButton
+ *         value="first"
+ *         status={ checked === 'first' ? 'checked' : 'unchecked' }
+ *         onPress={() => setChecked('first')}
+ *       />
+ *       <RadioButton
+ *         value="second"
+ *         status={ checked === 'second' ? 'checked' : 'unchecked' }
+ *         onPress={() => setChecked('second')}
+ *       />
+ *     </View>
+ *   );
+ * };
+ *
+ * export default MyComponent;
+ * ```
+ */
+
+const RadioButton = ({ disabled, onPress, value, status, ...rest }: Props) => {
+  const { colors } = useTheme<FxTheme>();
+  const { value: contextValue, onValueChange } = useRadioButtonContext();
+  const checked =
+    isChecked({
+      contextValue,
+      status,
+      value,
+    }) === 'checked';
+  const { current: borderAnim } = React.useRef<Animated.Value>(
+    new Animated.Value(checked ? BORDER_WIDTH_CHECKED : BORDER_WIDTH)
+  );
+
+  const { current: radioAnim } = React.useRef<Animated.Value>(
+    new Animated.Value(1)
+  );
+
+  const isFirstRendering = React.useRef<boolean>(true);
+
+  React.useEffect(() => {
+    // Do not run animation on very first rendering
+    if (isFirstRendering.current) {
+      isFirstRendering.current = false;
+      return;
+    }
+
+    if (checked) {
+      radioAnim.setValue(2.5);
+
+      Animated.timing(radioAnim, {
+        toValue: 1,
+        duration: 250,
+        useNativeDriver: true,
+      }).start();
+
+      Animated.timing(borderAnim, {
+        toValue: BORDER_WIDTH_CHECKED,
+        duration: 250,
+        useNativeDriver: false,
+      }).start();
+    } else {
+      Animated.timing(borderAnim, {
+        toValue: BORDER_WIDTH,
+        duration: 250,
+        useNativeDriver: false,
+      }).start();
+    }
+  }, [checked, borderAnim, radioAnim]);
+
+  const radioBackgroundColor = disabled
+    ? rest.uncheckedDisabledBackgroundColor || colors.backgroundSecondary
+    : undefined;
+  const checkedColor = rest.checkedColor || colors.greenBase;
+  const uncheckedColor = rest.uncheckedColor || colors.border;
+  const checkedDisabledColor = rest.checkedDisabledColor || colors.greenBorder;
+  const uncheckedDisabledColor = rest.uncheckedDisabledColor || colors.border;
+
+  let radioColor: string;
+  if (disabled) {
+    radioColor = checked ? checkedDisabledColor : uncheckedDisabledColor;
+  } else {
+    radioColor = checked ? checkedColor : uncheckedColor;
+  }
+
+  return (
+    <TouchableBox
+      style={s.container}
+      accessibilityRole="radio"
+      accessibilityState={{ disabled, checked }}
+      accessibilityLiveRegion="polite"
+      {...rest}
+      onPress={
+        disabled
+          ? undefined
+          : () => {
+              handlePress({
+                onPress,
+                onValueChange,
+                value,
+              });
+            }
+      }
+    >
+      <Animated.View
+        style={[
+          s.radio,
+          {
+            backgroundColor: radioBackgroundColor,
+            borderColor: radioColor,
+            borderWidth: borderAnim,
+          },
+        ]}
+      >
+        {checked ? (
+          <View style={[StyleSheet.absoluteFill, s.radioContainer]}>
+            <Animated.View
+              style={[
+                s.dot,
+                {
+                  backgroundColor: disabled ? colors.border : colors.white,
+                  transform: [{ scale: radioAnim }],
+                },
+              ]}
+            />
+          </View>
+        ) : null}
+      </Animated.View>
+    </TouchableBox>
+  );
+};
+
+RadioButton.displayName = 'RadioButton';
+
+const s = StyleSheet.create({
+  container: {
+    borderRadius: 18,
+  },
+  radioContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  radio: {
+    height: 18,
+    width: 18,
+    borderRadius: 10,
+  },
+  dot: {
+    height: 6,
+    width: 6,
+    borderRadius: 5,
+  },
+});
+
+export default RadioButton;
+
+export { RadioButton };

--- a/libs/component-library/src/lib/radio-button/RadioButton.tsx
+++ b/libs/component-library/src/lib/radio-button/RadioButton.tsx
@@ -1,24 +1,18 @@
-import { createBox, useTheme } from '@shopify/restyle';
+import { useTheme } from '@shopify/restyle';
 import * as React from 'react';
+import { Animated, View, StyleSheet } from 'react-native';
 import {
-  Animated,
-  View,
-  StyleSheet,
-  TouchableOpacity,
-  TouchableOpacityProps,
-} from 'react-native';
+  FxPressableOpacity,
+  FxPressableOpacityProps,
+} from '../pressable-opacity/pressableOpacity';
 import { FxTheme } from '../theme/theme';
 
-import type { $RemoveChildren } from './../types';
+import type { $Omit } from './../types';
 
 import { useRadioButtonContext } from './RadioButtonGroup';
 import { handlePress, isChecked } from './utils';
 
-const TouchableBox = createBox<FxTheme, TouchableOpacityProps>(
-  TouchableOpacity
-);
-
-type Props = $RemoveChildren<typeof TouchableBox> & {
+type Props = $Omit<FxPressableOpacityProps, 'children'> & {
   /**
    * Value of the radio button
    */
@@ -32,7 +26,7 @@ type Props = $RemoveChildren<typeof TouchableBox> & {
    */
   disabled?: boolean;
   /**
-   * Function to execute on press.
+   * Function to execute on internal onPress.
    */
   onPress?: () => void;
   /**
@@ -155,8 +149,8 @@ const RadioButton = ({ disabled, onPress, value, status, ...rest }: Props) => {
   }
 
   return (
-    <TouchableBox
-      style={s.container}
+    <FxPressableOpacity
+      borderRadius="l"
       accessibilityRole="radio"
       accessibilityState={{ disabled, checked }}
       accessibilityLiveRegion="polite"
@@ -197,16 +191,13 @@ const RadioButton = ({ disabled, onPress, value, status, ...rest }: Props) => {
           </View>
         ) : null}
       </Animated.View>
-    </TouchableBox>
+    </FxPressableOpacity>
   );
 };
 
 RadioButton.displayName = 'RadioButton';
 
 const s = StyleSheet.create({
-  container: {
-    borderRadius: 18,
-  },
   radioContainer: {
     alignItems: 'center',
     justifyContent: 'center',

--- a/libs/component-library/src/lib/radio-button/RadioButtonGroup.tsx
+++ b/libs/component-library/src/lib/radio-button/RadioButtonGroup.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { View } from 'react-native';
+
+type Props = {
+  /**
+   * Function to execute on selection change.
+   */
+  onValueChange: (value: string) => void;
+  /**
+   * Value of the currently selected radio button.
+   */
+  value: string;
+  /**
+   * React elements containing radio buttons.
+   */
+  children: React.ReactNode;
+};
+
+export type RadioButtonContextType = {
+  value: string;
+  onValueChange: (item: string) => void;
+};
+
+const initialContext: RadioButtonContextType = {
+  value: '',
+  onValueChange: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+};
+
+export const RadioButtonContext =
+  React.createContext<RadioButtonContextType>(initialContext);
+
+export const useRadioButtonContext = () => React.useContext(RadioButtonContext);
+
+/**
+ * Radio button group allows to control a group of radio buttons.
+ *
+ * ## Usage
+ * ```jsx
+ * import React from 'react';
+ * import { View } from 'react-native';
+ * import { RadioButton, Text } from 'components';
+ *
+ * const MyComponent = () => {
+ *   const [value, setValue] = React.useState('first');
+ *
+ *   return (
+ *     <RadioButton.Group onValueChange={newValue => setValue(newValue)} value={value}>
+ *       <View>
+ *         <Text>First</Text>
+ *         <RadioButton value="first" />
+ *       </View>
+ *       <View>
+ *         <Text>Second</Text>
+ *         <RadioButton value="second" />
+ *       </View>
+ *     </RadioButton.Group>
+ *   );
+ * };
+ *
+ * export default MyComponent;
+ *```
+ */
+const RadioButtonGroup = ({ value, onValueChange, children }: Props) => (
+  <RadioButtonContext.Provider value={{ value, onValueChange }}>
+    <View accessibilityRole="radiogroup">{children}</View>
+  </RadioButtonContext.Provider>
+);
+
+RadioButtonGroup.displayName = 'RadioButton.Group';
+export default RadioButtonGroup;
+
+export { RadioButtonGroup };

--- a/libs/component-library/src/lib/radio-button/RadioButtonGroup.tsx
+++ b/libs/component-library/src/lib/radio-button/RadioButtonGroup.tsx
@@ -37,8 +37,8 @@ export const useRadioButtonContext = () => React.useContext(RadioButtonContext);
  * ## Usage
  * ```jsx
  * import React from 'react';
- * import { View } from 'react-native';
- * import { RadioButton, Text } from 'components';
+ * import { View, Text } from 'react-native';
+ * import { RadioButton } from '@functionland/component-library';
  *
  * const MyComponent = () => {
  *   const [value, setValue] = React.useState('first');

--- a/libs/component-library/src/lib/radio-button/index.ts
+++ b/libs/component-library/src/lib/radio-button/index.ts
@@ -1,0 +1,11 @@
+import RadioButton from './RadioButton';
+import RadioButtonGroup from './RadioButtonGroup';
+
+export const FxRadioButton = Object.assign(
+  // @component ./RadioButton.tsx
+  RadioButton,
+  {
+    // @component ./RadioButtonGroup.tsx
+    Group: RadioButtonGroup,
+  }
+);

--- a/libs/component-library/src/lib/radio-button/utils.ts
+++ b/libs/component-library/src/lib/radio-button/utils.ts
@@ -1,0 +1,33 @@
+export const handlePress = ({
+  onPress,
+  value,
+  onValueChange,
+}: {
+  onPress?: () => void;
+  value: string;
+  onValueChange?: (value: string) => void;
+}) => {
+  if (onPress && onValueChange) {
+    console.warn(
+      `onPress in the scope of RadioButtonGroup will not be executed, use onValueChange instead`
+    );
+  }
+
+  onValueChange ? onValueChange(value) : onPress?.();
+};
+
+export const isChecked = ({
+  value,
+  status,
+  contextValue,
+}: {
+  value: string;
+  status?: 'checked' | 'unchecked';
+  contextValue?: string;
+}) => {
+  if (contextValue !== undefined && contextValue !== null) {
+    return contextValue === value ? 'checked' : 'unchecked';
+  } else {
+    return status;
+  }
+};

--- a/libs/component-library/src/lib/theme/theme.ts
+++ b/libs/component-library/src/lib/theme/theme.ts
@@ -69,6 +69,8 @@ const BaseTheme = {
     greenPressed: paletteLight.green700,
     greenBase: paletteLight.green600,
     greenHover: paletteLight.green500,
+    greenBorder: paletteLight.green400,
+    greenBackground: paletteLight.green100,
 
     errorBase: paletteLight.error600,
 
@@ -260,6 +262,8 @@ const fxDarkTheme: FxTheme = {
     greenPressed: paletteDark.green700,
     greenBase: paletteDark.green600,
     greenHover: paletteDark.green500,
+    greenBorder: paletteDark.green200,
+    greenBackground: paletteDark.green100,
 
     errorBase: paletteDark.error600,
   },

--- a/libs/component-library/src/lib/types.ts
+++ b/libs/component-library/src/lib/types.ts
@@ -1,0 +1,5 @@
+export type $Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+export type $RemoveChildren<T extends React.ComponentType> = $Omit<
+  React.ComponentPropsWithoutRef<T>,
+  'children'
+>;


### PR DESCRIPTION
Added Radio Buttons to component library.

These buttons can be used in two ways, either in a group where state is controlled by the Context in the Group or Directly with the Radio Button.

Group Use:
  ```jsx
  import React from 'react';
  import { View, Text } from 'react-native';
  import { RadioButton } from '@functionland/component-library';
 
  const MyComponent = () => {
    const [value, setValue] = React.useState('first');
 
    return (
      <RadioButton.Group onValueChange={newValue => setValue(newValue)} value={value}>
        <View>
          <Text>First</Text>
          <RadioButton value="first" />
        </View>
        <View>
          <Text>Second</Text>
          <RadioButton value="second" />
        </View>
      </RadioButton.Group>
    );
  };
 
  export default MyComponent;
 ```



Radio Button Direct Use:
```js
  import  React from 'react';
  import { View } from 'react-native';
  import { RadioButton } from '@functionland/component-library';
 
  const MyComponent = () => {
    const [checked, setChecked] = React.useState('first');
 
    return (
      <View>
        <RadioButton
          value="first"
          status={ checked === 'first' ? 'checked' : 'unchecked' }
          onPress={() => setChecked('first')}
        />
        <RadioButton
          value="second"
          status={ checked === 'second' ? 'checked' : 'unchecked' }
          onPress={() => setChecked('second')}
        />
      </View>
    );
  };
 
  export default MyComponent;
  ```
  
- closes: #144 

Screenshots:
![image](https://user-images.githubusercontent.com/17250443/183783912-a9b133af-4750-4227-8200-37bef9adbe57.png)
![image](https://user-images.githubusercontent.com/17250443/183783954-abb200f9-ed64-4b7b-a561-b8493b3a0e50.png)

