### PR TITLE
Fixes back button color for component navigator

### DIFF
--- a/apps/box/src/navigation/ComponentGallery.navigator.tsx
+++ b/apps/box/src/navigation/ComponentGallery.navigator.tsx
@@ -10,11 +10,18 @@ import { ComponentGalleryStackParamList } from './navigationConfig';
 type ComponentGalleryBackProps = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   navigation: any;
+  tintColor: string;
 };
-const ComponentGalleryBack = ({ navigation }: ComponentGalleryBackProps) => {
+const ComponentGalleryBack = ({
+  navigation,
+  tintColor,
+}: ComponentGalleryBackProps) => {
   return (
     <FxPressableOpacity onPress={() => navigation.goBack()}>
-      <Image source={require('../../assets/icons/back.png')} />
+      <Image
+        source={require('../../assets/icons/back.png')}
+        style={{ tintColor: tintColor }}
+      />
     </FxPressableOpacity>
   );
 };
@@ -32,11 +39,16 @@ export const ComponentGalleryNavigator = () => {
         },
         headerTitle: '',
         // eslint-disable-next-line react/no-unstable-nested-components
-        headerLeft: () => <ComponentGalleryBack navigation={navigation} />,
+        headerLeft: () => (
+          <ComponentGalleryBack
+            navigation={navigation}
+            tintColor={theme.colors.content1}
+          />
+        ),
       })}
     >
       <ComponentGalleryStack.Screen
-        name="Component Gallery"
+        name="Gallery"
         component={ComponentGalleryScreen}
       />
       <ComponentGalleryStack.Screen

--- a/apps/box/src/navigation/navigationConfig.ts
+++ b/apps/box/src/navigation/navigationConfig.ts
@@ -36,7 +36,7 @@ export type InitialSetupStackParamList = {
 };
 
 export type ComponentGalleryStackParamList = {
-  'Component Gallery': undefined;
+  Gallery: undefined;
   Avatars: undefined;
 };
 type MainTabsNavigationProp = CompositeNavigationProp<

--- a/apps/box/src/screens/Settings/ComponentGallery.screen.tsx
+++ b/apps/box/src/screens/Settings/ComponentGallery.screen.tsx
@@ -18,7 +18,7 @@ type GalleryItemType = {
 
 export const ComponentGalleryScreen = () => {
   const navigation =
-    useNavigation<ComponentGalleryStackNavigationProps<'Component Gallery'>>();
+    useNavigation<ComponentGalleryStackNavigationProps<'Gallery'>>();
   const galleryItems: GalleryItemType[] = [
     {
       name: 'Avatars',


### PR DESCRIPTION
Fixes back button color for component library navigator and fixes
up a warning about duplicate screen names.