### PR TITLE
Add support for icons in Tag component

### DIFF
--- a/libs/component-library/src/lib/tag/tag.tsx
+++ b/libs/component-library/src/lib/tag/tag.tsx
@@ -1,23 +1,24 @@
 import React from 'react';
-import {
-  boxRestyleFunctions,
-  composeRestyleFunctions,
-  useRestyle,
-} from '@shopify/restyle';
-import { FxTheme } from '../theme/theme';
 import { FxBox } from '../box/box';
 import { FxText } from '../text/text';
+import { FxSvgProps } from '../svg/svg';
+import { FxSpacer } from '../spacer/spacer';
 
 type FxTagProps = React.ComponentProps<typeof FxBox> & {
+  iconLeft?: React.ReactElement<FxSvgProps>;
+  iconRight?: React.ReactElement<FxSvgProps>;
   children: React.ReactNode;
 };
 
-const restyleFunctions = composeRestyleFunctions<FxTheme, FxTagProps>(
-  boxRestyleFunctions
-);
-
-const FxTag = (props: FxTagProps) => {
-  const { children, ...rest } = useRestyle(restyleFunctions, props);
+const FxTag = ({ iconLeft, iconRight, children, ...rest }: FxTagProps) => {
+  const renderIcon = (_icon: React.ReactElement<FxSvgProps>) => {
+    return React.createElement<FxSvgProps>(_icon.type, {
+      height: 14,
+      width: 14,
+      color: 'content1',
+      ..._icon.props,
+    });
+  };
 
   return (
     <FxBox
@@ -26,11 +27,25 @@ const FxTag = (props: FxTagProps) => {
       height={26}
       justifyContent="center"
       paddingHorizontal="8"
+      flexDirection="row"
+      alignItems="center"
       {...rest}
     >
+      {iconLeft && (
+        <>
+          {renderIcon(iconLeft)}
+          <FxSpacer width={8} />
+        </>
+      )}
       <FxText color="content1" variant="bodyXXSRegular">
         {children}
       </FxText>
+      {iconRight && (
+        <>
+          <FxSpacer width={8} />
+          {renderIcon(iconRight)}
+        </>
+      )}
     </FxBox>
   );
 };


### PR DESCRIPTION
Adds support for rendering left and/or right icons in Tag component.

Resolves #206 