### PR TITLE
Feat/breadcrumbs

### DIFF
--- a/apps/box/src/navigation/ComponentGallery.navigator.tsx
+++ b/apps/box/src/navigation/ComponentGallery.navigator.tsx
@@ -15,6 +15,7 @@ import {
   ToastDemoScreen,
   FormDemoScreen,
   ButtonsDemoScreen,
+  BreadcrumbsDemoScreen,
 } from '../screens/Settings/ComponentGallery';
 import { ComponentGalleryStackParamList } from './navigationConfig';
 import { TableDemoScreen } from '../screens/Settings/ComponentGallery/TableDemo.screen';
@@ -84,6 +85,10 @@ export const ComponentGalleryNavigator = () => {
       <ComponentGalleryStack.Screen name="Toast" component={ToastDemoScreen} />
       <ComponentGalleryStack.Screen name="Usage Bar" component={UsageBarDemo} />
       <ComponentGalleryStack.Screen name="Table" component={TableDemoScreen} />
+      <ComponentGalleryStack.Screen
+        name="Breadcrumbs"
+        component={BreadcrumbsDemoScreen}
+      />
     </ComponentGalleryStack.Navigator>
   );
 };

--- a/apps/box/src/navigation/navigationConfig.ts
+++ b/apps/box/src/navigation/navigationConfig.ts
@@ -46,6 +46,7 @@ export type ComponentGalleryStackParamList = {
   Tabs: undefined;
   Toast: undefined;
   Table: undefined;
+  Breadcrumbs: undefined;
 };
 type MainTabsNavigationProp = CompositeNavigationProp<
   BottomTabNavigationProp<MainTabsParamList>,

--- a/apps/box/src/screens/Settings/ComponentGallery.screen.tsx
+++ b/apps/box/src/screens/Settings/ComponentGallery.screen.tsx
@@ -74,6 +74,12 @@ export const ComponentGalleryScreen = () => {
         navigation.navigate('Table');
       },
     },
+    {
+      name: 'Breadcrumbs',
+      onPress: () => {
+        navigation.navigate('Breadcrumbs');
+      },
+    },
   ];
 
   const renderItem = React.useCallback<ListRenderItem<GalleryItemType>>(
@@ -101,7 +107,6 @@ export const ComponentGalleryScreen = () => {
         data={galleryItems}
         renderItem={renderItem}
         ItemSeparatorComponent={ItemSeparatorComponent}
-        contentContainerStyle={styles.listContainer}
       />
     </FxSafeAreaBox>
   );
@@ -110,9 +115,3 @@ export const ComponentGalleryScreen = () => {
 const ItemSeparatorComponent = () => {
   return <FxSpacer marginTop="8" />;
 };
-
-const styles = StyleSheet.create({
-  listContainer: {
-    flex: 1,
-  },
-});

--- a/apps/box/src/screens/Settings/ComponentGallery.screen.tsx
+++ b/apps/box/src/screens/Settings/ComponentGallery.screen.tsx
@@ -7,7 +7,7 @@ import {
 } from '@functionland/component-library';
 import { useNavigation } from '@react-navigation/native';
 import React from 'react';
-import { FlatList, ListRenderItem, StyleSheet } from 'react-native';
+import { FlatList, ListRenderItem } from 'react-native';
 import { HeaderText } from '../../components/Text';
 import { ComponentGalleryStackNavigationProps } from '../../navigation/navigationConfig';
 

--- a/apps/box/src/screens/Settings/ComponentGallery/BreadcrumbsDemo.screen.tsx
+++ b/apps/box/src/screens/Settings/ComponentGallery/BreadcrumbsDemo.screen.tsx
@@ -1,0 +1,34 @@
+import {
+  FxSafeAreaBox,
+  FxSpacer,
+  FxBreadcrumbs,
+  FxBreadcrumbsProps,
+} from '@functionland/component-library';
+import { HeaderText } from '../../../components/Text';
+import React from 'react';
+import { Alert } from 'react-native';
+
+const demoPath: FxBreadcrumbsProps['path'] = [
+  {
+    label: 'Office Blox Unit',
+    onPress: (item) => Alert.alert('Link clicked', `${item.label}`),
+  },
+  {
+    label: 'Tower #2',
+    onPress: (item) => Alert.alert('Link clicked', `${item.label}`),
+  },
+  {
+    label: 'Card #3',
+    onPress: (item) => Alert.alert('Link clicked', `${item.label}`),
+  },
+];
+
+export const BreadcrumbsDemoScreen = () => {
+  return (
+    <FxSafeAreaBox flex={1} marginHorizontal={'20'}>
+      <HeaderText>Breadcrumbs</HeaderText>
+      <FxSpacer marginTop="24" />
+      <FxBreadcrumbs path={demoPath} />
+    </FxSafeAreaBox>
+  );
+};

--- a/apps/box/src/screens/Settings/ComponentGallery/index.tsx
+++ b/apps/box/src/screens/Settings/ComponentGallery/index.tsx
@@ -6,3 +6,4 @@ export * from './TabsDemo.screen';
 export * from './ToastDemo.screen';
 export * from './UsageBarDemo.screen';
 export * from './ButtonsDemo.screen';
+export * from './BreadcrumbsDemo.screen';

--- a/libs/component-library/src/index.ts
+++ b/libs/component-library/src/index.ts
@@ -41,3 +41,4 @@ export { useFxTheme } from './lib/theme/useFxTheme';
 export * from './lib/toast';
 export * from './lib/link/link';
 export { FxPressableOpacity } from './lib/pressable-opacity/pressableOpacity';
+export * from './lib/breadcrumbs/breadcrumbs';

--- a/libs/component-library/src/lib/breadcrumbs/breadcrumbs.tsx
+++ b/libs/component-library/src/lib/breadcrumbs/breadcrumbs.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { FxBox, FxBoxProps } from '../box/box';
+import { FxChevronRightIcon } from '../icons/icons';
+import { FxPressableOpacity } from '../pressable-opacity/pressableOpacity';
+import { FxSpacer } from '../spacer/spacer';
+import { FxText, FxTextProps } from '../text/text';
+import { useFxTheme } from '../theme/useFxTheme';
+
+type PathBase = {
+  label: FxTextProps['children'];
+  onPress: (item: PathBase) => void;
+};
+
+export type FxBreadcrumbsProps = FxBoxProps & {
+  path: PathBase[];
+};
+
+export const FxBreadcrumbs = ({ path, ...rest }: FxBreadcrumbsProps) => {
+  const { colors } = useFxTheme();
+
+  return (
+    <FxBox flexDirection="row" alignItems="center" {...rest}>
+      {path.map((item, idx) => (
+        <>
+          <FxPressableOpacity
+            onPress={() => item.onPress(item)}
+            alignItems="center"
+            justifyContent="center"
+          >
+            <FxText variant="bodyXSRegular" color="content1">
+              {item.label}
+            </FxText>
+          </FxPressableOpacity>
+          {idx !== path.length - 1 && (
+            <>
+              <FxSpacer width={6} />
+              <FxChevronRightIcon
+                fill={colors.content1}
+                width="16"
+                height="16"
+              />
+              <FxSpacer width={6} />
+            </>
+          )}
+        </>
+      ))}
+    </FxBox>
+  );
+};

--- a/libs/component-library/src/lib/breadcrumbs/breadcrumbs.tsx
+++ b/libs/component-library/src/lib/breadcrumbs/breadcrumbs.tsx
@@ -20,30 +20,37 @@ export const FxBreadcrumbs = ({ path, ...rest }: FxBreadcrumbsProps) => {
 
   return (
     <FxBox flexDirection="row" alignItems="center" {...rest}>
-      {path.map((item, idx) => (
-        <>
-          <FxPressableOpacity
-            onPress={() => item.onPress(item)}
-            alignItems="center"
-            justifyContent="center"
-          >
-            <FxText variant="bodyXSRegular" color="content1">
-              {item.label}
-            </FxText>
-          </FxPressableOpacity>
-          {idx !== path.length - 1 && (
-            <>
-              <FxSpacer width={6} />
-              <FxChevronRightIcon
-                fill={colors.content1}
-                width="16"
-                height="16"
-              />
-              <FxSpacer width={6} />
-            </>
-          )}
-        </>
-      ))}
+      {path.map((item, idx) => {
+        const isLast = idx === path.length - 1;
+
+        return (
+          <FxBox key={`crumb-${idx}`} flexDirection="row" alignItems="center">
+            <FxPressableOpacity
+              onPress={() => item.onPress(item)}
+              alignItems="center"
+              justifyContent="center"
+            >
+              <FxText
+                variant={isLast ? 'bodyXSSemibold' : 'bodyXSRegular'}
+                color="content1"
+              >
+                {item.label}
+              </FxText>
+            </FxPressableOpacity>
+            {!isLast && (
+              <>
+                <FxSpacer width={6} />
+                <FxChevronRightIcon
+                  fill={colors.content1}
+                  width="16"
+                  height="16"
+                />
+                <FxSpacer width={6} />
+              </>
+            )}
+          </FxBox>
+        );
+      })}
     </FxBox>
   );
 };


### PR DESCRIPTION
Added Breadcrumbs component to library and demo screen

<img width="259" alt="image" src="https://user-images.githubusercontent.com/17250443/189162697-ca6b3dd2-b61e-4222-b648-e4ee4b1ce91f.png">
<img width="251" alt="image" src="https://user-images.githubusercontent.com/17250443/189162824-b721ba99-51f3-4e3b-9b08-1402b1467f86.png">




https://user-images.githubusercontent.com/17250443/189135713-3c521c49-8c4d-413c-bb7f-3e916643a6dd.mp4




closes #164 